### PR TITLE
feat: track failed requests and expose Failures panel

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,35 @@
+# Testing Guide
+
+## Build the extension
+
+```
+cd omega-build
+npm run deps
+npm run dev
+npm run build
+```
+
+Built files appear in `omega-target-chromium-extension/build`.
+
+## Enable logging
+
+Open the background service worker console in your browser's extensions page to view log output and captured failures.
+
+## View failures
+
+1. Load the unpacked extension in Chromium or Orion.
+2. Open the options page and select the **Failures (beta)** tab.
+3. Trigger a failing network request (e.g. visit a blocked or invalid domain).
+4. The failing host should appear in the list within a few seconds.
+5. Use **Refresh** to update manually or keep auto‑refresh enabled.
+
+## Add to proxy list
+
+1. In the **Failures (beta)** panel, click **Add to Proxy list** for a host.
+2. The background script POSTs `{"domain": "<host>"}` to `http://127.0.0.1:9099/add-domain`.
+3. A toast indicates success or failure.
+
+## Orion verification
+
+On macOS, load the extension in Orion as an unpacked extension.
+Confirm that network failures populate the panel and that the POST to the local endpoint succeeds.

--- a/omega-target-chromium-extension/overlay/manifest.json
+++ b/omega-target-chromium-extension/overlay/manifest.json
@@ -43,8 +43,7 @@
     "storage",
     "unlimitedStorage",
     "webRequest",
-    "webRequestAuthProvider",
     "contextMenus"
   ],
-  "host_permissions": ["<all_urls>"]
+  "host_permissions": ["<all_urls>", "http://127.0.0.1/*"]
 }

--- a/omega-target-chromium-extension/src/coffee/background.coffee
+++ b/omega-target-chromium-extension/src/coffee/background.coffee
@@ -6,6 +6,10 @@ OmegaTargetCurrent.Log = Object.create(OmegaTargetCurrent.Log)
 Log = OmegaTargetCurrent.Log
 
 
+FailedHosts = require('../module/failed_hosts')
+failedHosts = new FailedHosts()
+
+
 BUILTINSYNCKEY = 'zeroOmegaSync'
 
 globalThis.isBrowserRestart = false
@@ -447,7 +451,18 @@ zeroBackground = (zeroStorage, opts) ->
         chrome.storage.local.clear()
       ])
   chrome.runtime.onMessage.addListener (request, sender, respond) ->
-    return unless request and request.method
+    if request?.type == 'GET_FAILED_HOSTS'
+      failedHosts.list().then (list) -> respond(list)
+      return true
+    if request?.type == 'CLEAR_FAILED_HOSTS'
+      failedHosts.clear().then -> respond(ok: true)
+      return true
+    if request?.type == 'SEND_HOST_TO_LOCAL'
+      failedHosts.send(request.host).then (res) -> respond(res)
+      return true
+
+    return unless request?.method
+
     options.ready.then ->
       if request.method == 'resetAllOptions'
         target = globalThis

--- a/omega-target-chromium-extension/src/module/failed_hosts.coffee
+++ b/omega-target-chromium-extension/src/module/failed_hosts.coffee
@@ -1,0 +1,111 @@
+api = chrome ? browser
+storage = api.storage?.session ? api.storage?.local
+MAX = 200
+DEBOUNCE = 1000
+IGNORES = [
+  'sentry.io'
+  'doubleclick.net'
+  'googletagmanager.com'
+  'facebook.net'
+  'scorecardresearch.com'
+  'adsystem'
+]
+
+module.exports = class FailedHosts
+  constructor: ->
+    @hosts = {}
+    @order = []
+    @lastEvents = {}
+    storage?.get {failedHosts: []}, (res) =>
+      for item in res?.failedHosts ? []
+        @hosts[item.host] = item
+        @order.push item.host
+    if api.webRequest?
+      filter = {urls: ['<all_urls>']}
+      api.webRequest.onErrorOccurred.addListener(@_onError, filter)
+      api.webRequest.onCompleted.addListener(@_onCompleted, filter)
+
+  _save: ->
+    items = @order.map (h) => @hosts[h]
+    storage?.set {failedHosts: items}
+
+  _record: (host, error, tabId) =>
+    for i in IGNORES when host.includes(i)
+      return
+    now = Date.now()
+    key = host + '|' + error
+    last = @lastEvents[key]
+    return if last? and now - last < DEBOUNCE
+    @lastEvents[key] = now
+    entry = @hosts[host]
+    if entry?
+      entry.lastError = error
+      entry.lastSeen = now
+      entry.hits += 1
+    else
+      entry =
+        host: host
+        lastError: error
+        firstSeen: now
+        lastSeen: now
+        hits: 1
+        pageOrigins: []
+      @hosts[host] = entry
+      @order.unshift host
+      if @order.length > MAX
+        old = @order.pop()
+        delete @hosts[old]
+    if tabId? and tabId >= 0 and api.tabs?
+      try
+        api.tabs.get tabId, (tab) =>
+          origin = ''
+          try
+            origin = new URL(tab.url).origin if tab?.url
+          if origin and origin != 'null'
+            idx = entry.pageOrigins.indexOf(origin)
+            entry.pageOrigins.splice(idx,1) if idx >= 0
+            entry.pageOrigins.unshift origin
+            entry.pageOrigins = entry.pageOrigins.slice(0,5)
+          @_save()
+      catch err
+        @_save()
+    else
+      @_save()
+
+  _onError: (details) =>
+    try
+      host = new URL(details.url).hostname
+    catch err
+      return
+    @_record host, details.error, details.tabId
+
+  _onCompleted: (details) =>
+    return unless details.statusCode? and details.statusCode >= 400
+    try
+      host = new URL(details.url).hostname
+    catch err
+      return
+    @_record host, '' + details.statusCode, details.tabId
+
+  list: ->
+    list = @order.map (h) => @hosts[h]
+    list.sort (a, b) -> b.lastSeen - a.lastSeen
+    Promise.resolve list
+
+  clear: ->
+    @hosts = {}
+    @order = []
+    @lastEvents = {}
+    @_save()
+    Promise.resolve()
+
+  send: (host) ->
+    fetch 'http://127.0.0.1:9099/add-domain',
+      method: 'POST'
+      headers:
+        'Content-Type': 'application/json'
+      body: JSON.stringify domain: host
+    .then (res) ->
+      {ok: res.ok}
+    .catch (e) ->
+      {ok: false, error: e.message}

--- a/omega-target-chromium-extension/src/module/index.coffee
+++ b/omega-target-chromium-extension/src/module/index.coffee
@@ -6,6 +6,7 @@ module.exports =
   SwitchySharp: require('./switchysharp')
   ExternalApi: require('./external_api')
   WebRequestMonitor: require('./web_request_monitor')
+  FailedHosts: require('./failed_hosts')
   Inspect: require('./inspect')
   Url: require('url')
   proxy: require('./proxy')

--- a/omega-web/src/omega/app.coffee
+++ b/omega-web/src/omega/app.coffee
@@ -65,6 +65,10 @@ $httpProvider, $animateProvider, $compileProvider) ->
     ).state('theme',
       url: '/theme'
       templateUrl: 'partials/theme.html'
+    ).state('failures',
+      url: '/failures'
+      templateUrl: 'partials/failures.html'
+      controller: 'FailuresCtrl'
     ).state('profile',
       url: '/profile/*name'
       templateUrl: 'partials/profile.html'

--- a/omega-web/src/omega/controllers/failures.coffee
+++ b/omega-web/src/omega/controllers/failures.coffee
@@ -1,0 +1,43 @@
+angular.module('omega').controller 'FailuresCtrl', (
+  $scope, $rootScope, $interval, failedHosts
+) ->
+  $scope.failed = []
+  $scope.search = ''
+  $scope.autoRefresh = true
+
+  timer = null
+  refresh = ->
+    failedHosts.list().then (list) ->
+      $scope.failed = list
+  $scope.refresh = refresh
+
+  $scope.clear = ->
+    failedHosts.clear().then ->
+      $scope.failed = []
+
+  $scope.toggleAuto = ->
+    if $scope.autoRefresh
+      start()
+    else
+      stop()
+
+  start = ->
+    stop()
+    timer = $interval(refresh, 5000)
+  stop = ->
+    $interval.cancel(timer) if timer?
+    timer = null
+
+  $scope.add = (host) ->
+    failedHosts.send(host).then (res) ->
+      if res?.ok
+        $rootScope.showAlert type: 'success', message: 'Added'
+      else
+        $rootScope.showAlert type: 'error', message: res?.error or 'Error'
+  $scope.copy = (host) ->
+    navigator.clipboard?.writeText(host)
+    $rootScope.showAlert type: 'success', message: 'Copied'
+
+  $scope.$on '$destroy', stop
+  refresh()
+  start()

--- a/omega-web/src/omega/failed_hosts.coffee
+++ b/omega-web/src/omega/failed_hosts.coffee
@@ -1,0 +1,12 @@
+angular.module('omega').factory 'failedHosts', ($q) ->
+  send = (msg) ->
+    d = $q.defer()
+    chrome.runtime.sendMessage msg, (res) ->
+      if chrome.runtime.lastError?
+        d.reject chrome.runtime.lastError
+      else
+        d.resolve res
+    d.promise
+  list: -> send type: 'GET_FAILED_HOSTS'
+  clear: -> send type: 'CLEAR_FAILED_HOSTS'
+  send: (host) -> send type: 'SEND_HOST_TO_LOCAL', host: host

--- a/omega-web/src/options.jade
+++ b/omega-web/src/options.jade
@@ -37,6 +37,10 @@ html(lang='en' ng-controller='MasterCtrl' ng-csp)
             span.glyphicon.glyphicon-adjust
             = ' '
             | {{'options_theme' | tr}}
+          li(ui-sref-active='active'): a(ui-sref='failures')
+            span.glyphicon.glyphicon-exclamation-sign
+            = ' '
+            | Failures (beta)
           li.divider
           li.nav-header {{'options_navHeader_profiles' | tr}}
           li(ui-sref-active='active'): a(ui-sref='builtin')

--- a/omega-web/src/partials/failures.jade
+++ b/omega-web/src/partials/failures.jade
@@ -1,0 +1,45 @@
+.page-header
+  h2 Failures (beta)
+section.settings-group
+  .btn-toolbar
+    button.btn.btn-default(ng-click='refresh()')
+      span.glyphicon.glyphicon-refresh
+      = ' '
+      | Refresh
+    button.btn.btn-default(ng-click='clear()')
+      span.glyphicon.glyphicon-trash
+      = ' '
+      | Clear
+    label.checkbox
+      input(type='checkbox' ng-model='autoRefresh' ng-change='toggleAuto()')
+      span Auto-refresh
+  .form-group
+    input.form-control(type='text' ng-model='search' placeholder='Search')
+  table.table.table-striped
+    thead
+      tr
+        th Host
+        th Error
+        th First seen
+        th Last seen
+        th Hits
+        th Origin
+        th
+    tbody
+      tr(ng-repeat='f in failed | filter:search track by f.host')
+        td {{f.host}}
+        td {{f.lastError}}
+        td {{f.firstSeen | date:"short"}}
+        td {{f.lastSeen | date:"short"}}
+        td {{f.hits}}
+        td {{f.pageOrigins[0]}}
+        td
+          button.btn.btn-xs.btn-primary(ng-click='add(f.host)')
+            span.glyphicon.glyphicon-plus
+            = ' '
+            | Add to Proxy list
+          = ' '
+          button.btn.btn-xs.btn-default(ng-click='copy(f.host)')
+            span.glyphicon.glyphicon-copy
+            = ' '
+            | Copy host


### PR DESCRIPTION
## Summary
- capture failed network requests and keep recent host list
- add messaging endpoints to view, clear, and send hosts to local service
- surface failures in new "Failures (beta)" options tab with refresh and copy actions
- consolidate background message handling and persist host list with storage fallback
- trim extension permissions

## Testing
- `npm run deps`
- `npm run dev`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f9694030c832b967c1ca155a11858