### PR TITLE
feat: add failure catcher extension

### DIFF
--- a/failure-catcher/background.js
+++ b/failure-catcher/background.js
@@ -1,0 +1,119 @@
+/* Background script for ZeroOmega Failure Catcher */
+const LOG_PREFIX = '[background]';
+const HEARTBEAT_INTERVAL = 30000; // 30s
+const DEBOUNCE_MS = 4000; // 4s
+const MAX_BUFFER = 200;
+const IGNORE = ['sentry.io', 'googletagmanager.com', 'doubleclick.net', 'facebook.net', 'scorecardresearch.com', 'adsystem'];
+
+let failedHosts = [];
+const debounceMap = new Map();
+
+function log(...args) {
+  console.log(LOG_PREFIX, ...args);
+}
+
+function normalizeHost(url) {
+  try {
+    const u = new URL(url);
+    let host = u.hostname.toLowerCase();
+    if (host.startsWith('www.')) host = host.slice(4);
+    // Skip IP addresses
+    if (/^\d{1,3}(\.\d{1,3}){3}$/.test(host) || /^\[[0-9a-f:]+\]$/.test(host)) return null;
+    return host;
+  } catch (e) {
+    log('normalizeHost failed', url, e);
+    return null;
+  }
+}
+
+function loadFromStorage() {
+  chrome.storage.session.get({failedHosts: []}, data => {
+    if (chrome.runtime.lastError) log('storage get error', chrome.runtime.lastError);
+    failedHosts = data.failedHosts || [];
+    log('loaded from storage', failedHosts.length);
+  });
+}
+
+function saveToStorage() {
+  chrome.storage.session.set({failedHosts}, () => {
+    if (chrome.runtime.lastError) log('storage set error', chrome.runtime.lastError);
+    log('storage updated', failedHosts.length);
+    chrome.runtime.sendMessage({type: 'failed_hosts_updated'}, () => {
+      if (chrome.runtime.lastError) log('broadcast error', chrome.runtime.lastError);
+    });
+  });
+}
+
+function shouldIgnore(host) {
+  return IGNORE.some(p => host.includes(p));
+}
+
+function addFailure(host, error) {
+  const key = host + '|' + error;
+  const now = Date.now();
+  const last = debounceMap.get(key) || 0;
+  if (now - last < DEBOUNCE_MS) {
+    log('debounce', host, error);
+    return;
+  }
+  debounceMap.set(key, now);
+  if (shouldIgnore(host)) {
+    log('ignored host', host);
+    return;
+  }
+  failedHosts.push({host, error, time: now});
+  if (failedHosts.length > MAX_BUFFER) failedHosts = failedHosts.slice(-MAX_BUFFER);
+  log('captured', host, error);
+  saveToStorage();
+}
+
+function handleCompleted(details) {
+  if (details.statusCode >= 400) {
+    const host = normalizeHost(details.url);
+    if (host) addFailure(host, String(details.statusCode));
+  }
+}
+
+function handleError(details) {
+  const host = normalizeHost(details.url);
+  if (host) addFailure(host, details.error || 'error');
+}
+
+chrome.webRequest.onCompleted.addListener(handleCompleted, {urls: ['<all_urls>']});
+chrome.webRequest.onErrorOccurred.addListener(handleError, {urls: ['<all_urls>']});
+log('listeners registered');
+
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  log('message received', msg);
+  if (msg && msg.type === 'GET_FAILED_HOSTS') {
+    sendResponse({hosts: failedHosts});
+  } else if (msg && msg.type === 'CLEAR_FAILED_HOSTS') {
+    const count = failedHosts.length;
+    failedHosts = [];
+    saveToStorage();
+    sendResponse({ok: true, countCleared: count});
+  } else if (msg && msg.type === 'ADD_TO_PROXY') {
+    const domains = msg.hosts || [];
+    const payload = {domains};
+    const endpoint = 'http://127.0.0.1:9099/add-domain';
+    log('POST start', endpoint, payload);
+    fetch(endpoint, {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify(payload)
+    }).then(res => {
+      log('POST success', res.status);
+      sendResponse({ok: true, status: res.status});
+    }).catch(err => {
+      log('POST error', err);
+      sendResponse({ok: false, error: String(err)});
+    });
+    return true;
+  }
+  return true;
+});
+
+setInterval(() => log('SW alive', new Date().toISOString()), HEARTBEAT_INTERVAL);
+
+log('startup', new Date().toISOString(), navigator.userAgent);
+loadFromStorage();

--- a/failure-catcher/manifest.json
+++ b/failure-catcher/manifest.json
@@ -1,0 +1,21 @@
+{
+  "manifest_version": 3,
+  "name": "ZeroOmega Failure Catcher",
+  "version": "0.1.0",
+  "description": "Captures failing domains and sends them to a local service.",
+  "permissions": [
+    "storage",
+    "webRequest",
+    "webRequestBlocking"
+  ],
+  "host_permissions": [
+    "<all_urls>",
+    "http://127.0.0.1/*"
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "action": {
+    "default_popup": "popup.html"
+  }
+}

--- a/failure-catcher/popup.html
+++ b/failure-catcher/popup.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <style>
+    body { font-family: sans-serif; width: 300px; }
+    #status { margin-top: 8px; font-size: 0.9em; }
+    ul { list-style: none; padding: 0; }
+    li { display: flex; align-items: center; }
+    li span { flex: 1; }
+  </style>
+</head>
+<body>
+  <h3>Failures</h3>
+  <input type="text" id="filter" placeholder="Filter">
+  <button id="refresh">Refresh</button>
+  <button id="selectAll">Select all</button>
+  <button id="clear">Clear</button>
+  <ul id="list"></ul>
+  <input type="text" id="manualDomain" placeholder="example.com">
+  <button id="addManual">Add domain</button>
+  <button id="addSelected">Add selected to Proxy</button>
+  <div id="status"></div>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/failure-catcher/popup.js
+++ b/failure-catcher/popup.js
@@ -1,0 +1,115 @@
+const LOG_PREFIX = '[popup]';
+let failedHosts = [];
+
+function log(...args) {
+  console.log(LOG_PREFIX, ...args);
+}
+
+function setStatus(msg, isError=false) {
+  const el = document.getElementById('status');
+  el.textContent = msg;
+  el.style.color = isError ? 'red' : 'green';
+}
+
+function requestHosts() {
+  log('requesting failed hosts');
+  chrome.runtime.sendMessage({type: 'GET_FAILED_HOSTS'}, resp => {
+    if (chrome.runtime.lastError) {
+      log('GET_FAILED_HOSTS error', chrome.runtime.lastError);
+      return;
+    }
+    log('received hosts', resp);
+    failedHosts = resp.hosts || [];
+    renderList();
+  });
+}
+
+function renderList() {
+  log('render list');
+  const filter = document.getElementById('filter').value.toLowerCase();
+  const ul = document.getElementById('list');
+  ul.innerHTML = '';
+  failedHosts.filter(h => !filter || h.host.includes(filter)).forEach((h, idx) => {
+    const li = document.createElement('li');
+    const cb = document.createElement('input');
+    cb.type = 'checkbox';
+    cb.dataset.host = h.host;
+    li.appendChild(cb);
+    const span = document.createElement('span');
+    span.textContent = h.host + ' (' + h.error + ')';
+    li.appendChild(span);
+    ul.appendChild(li);
+  });
+}
+
+document.getElementById('refresh').addEventListener('click', () => {
+  log('refresh clicked');
+  requestHosts();
+});
+
+document.getElementById('selectAll').addEventListener('click', () => {
+  log('select all');
+  document.querySelectorAll('#list input[type=checkbox]').forEach(cb => cb.checked = true);
+});
+
+document.getElementById('clear').addEventListener('click', () => {
+  log('clear clicked');
+  chrome.runtime.sendMessage({type: 'CLEAR_FAILED_HOSTS'}, resp => {
+    if (chrome.runtime.lastError) {
+      log('CLEAR_FAILED_HOSTS error', chrome.runtime.lastError);
+      setStatus('Error clearing', true);
+      return;
+    }
+    log('cleared', resp);
+    setStatus('Cleared ' + resp.countCleared);
+    requestHosts();
+  });
+});
+
+document.getElementById('addSelected').addEventListener('click', () => {
+  const hosts = Array.from(document.querySelectorAll('#list input[type=checkbox]:checked')).map(cb => cb.dataset.host);
+  log('add selected', hosts);
+  if (!hosts.length) { setStatus('No hosts selected', true); return; }
+  setStatus('Sending...');
+  chrome.runtime.sendMessage({type: 'ADD_TO_PROXY', hosts}, resp => {
+    if (chrome.runtime.lastError) {
+      log('ADD_TO_PROXY error', chrome.runtime.lastError);
+      setStatus('Error sending', true);
+      return;
+    }
+    log('ADD_TO_PROXY response', resp);
+    setStatus(resp.ok ? 'Sent (' + resp.status + ')' : 'Failed', !resp.ok);
+  });
+});
+
+document.getElementById('addManual').addEventListener('click', () => {
+  const domain = document.getElementById('manualDomain').value.trim();
+  if (!domain) { setStatus('Enter domain', true); return; }
+  log('add manual', domain);
+  chrome.runtime.sendMessage({type: 'ADD_TO_PROXY', hosts: [domain]}, resp => {
+    if (chrome.runtime.lastError) {
+      log('ADD_TO_PROXY manual error', chrome.runtime.lastError);
+      setStatus('Error sending', true);
+      return;
+    }
+    log('manual add response', resp);
+    setStatus(resp.ok ? 'Sent (' + resp.status + ')' : 'Failed', !resp.ok);
+  });
+});
+
+document.getElementById('filter').addEventListener('input', () => {
+  log('filter change');
+  renderList();
+});
+
+chrome.runtime.onMessage.addListener((msg) => {
+  if (msg && msg.type === 'failed_hosts_updated') {
+    log('failed_hosts_updated received');
+    requestHosts();
+  }
+});
+
+document.addEventListener('DOMContentLoaded', () => {
+  log('popup init');
+  requestHosts();
+});


### PR DESCRIPTION
## Summary
- add minimal MV3 failure catcher with background listeners and verbose logging
- show failing domains in popup with selection and manual entry
- post selected domains to local endpoint

## Testing
- `cd omega-build && npm run deps`
- `cd omega-build && npm run dev`
- `cd omega-build && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689fc4c521d0832b9e20a30e56f7b61c