### PR TITLE
feat: prune failures and add clear-all button

### DIFF
--- a/failure-catcher/popup.html
+++ b/failure-catcher/popup.html
@@ -15,7 +15,7 @@
   <input type="text" id="filter" placeholder="Filter">
   <button id="refresh">Refresh</button>
   <button id="selectAll">Select all</button>
-  <button id="clear">Clear</button>
+  <button id="clearAll">Clear all</button>
   <ul id="list"></ul>
   <input type="text" id="manualDomain" placeholder="example.com">
   <button id="addManual">Add domain</button>


### PR DESCRIPTION
## Summary
- add timestamped logs and background pruning for hosts added to proxy
- provide Clear all action to empty failure list and storage
- parse add-to-proxy responses for partial success and prune successes

## Testing
- `npm test` *(fails: enoent package.json)*
- `node --check failure-catcher/background.js`
- `node --check failure-catcher/popup.js`


------
https://chatgpt.com/codex/tasks/task_e_689fd4a327e0832bbd0f53857e90012b